### PR TITLE
Residual connection fix (and highway layer)

### DIFF
--- a/modules.py
+++ b/modules.py
@@ -150,17 +150,24 @@ def prenet(inputs, is_training=True, variable_scope="prenet"):
         outputs = tf.nn.dropout(outputs, .5) 
     return outputs # (N, T, 128)
     
-def highwaynet(inputs, is_training=True, variable_scope="highwaynet"):
-    '''Refer to https://arxiv.org/abs/1505.00387'''
+def highwaynet(inputs, units=None, is_training=True, variable_scope="highwaynet"):
+    '''Highway networks, see https://arxiv.org/abs/1505.00387
+
+    Args:
+      inputs: A 3D tensor of shape [N, T, W].
+      units: An int or `None`. Specifies the number of units in the highway layer
+             or uses the input size if `None`.
+
+    Returns:
+      A 3D tensor of shape [N, T, W].
+    '''
+    if not units:
+        units = inputs.get_shape()[-1]
     with tf.variable_scope(variable_scope):
-        H = dense(inputs, hp.embed_size, act="relu", 
-                  is_training=is_training, variable_scope="dense1")
-#         H = tf.contrib.layers.fully_connected(inputs, hp.embed_size, activation_fn=tf.nn.relu)
-#         T = tf.contrib.layers.fully_connected(inputs, hp.embed_size, activation_fn=tf.nn.sigmoid)
-        T = dense(inputs, hp.embed_size, act="sigmoid", 
-                  is_training=is_training, variable_scope="dense2")
+        H = tf.layers.dense(inputs, units=units, activation=tf.nn.relu,
+                  trainable=is_training, name="dense1")
+        T = tf.layers.dense(inputs, units=units, activation=tf.nn.sigmoid,
+                  trainable=is_training, name="dense2")
         C = 1. - T
         outputs = H * T + inputs * C
     return outputs
-  
-    


### PR DESCRIPTION
Hi again,

This PR is two-fold.

# Residual connection

In my opinion, the residual connections from the CBHG have to be applied from _after_ the pre-net and not from the inputs directly.

There are two arguments which speak for this interpretation:
* the residual connection is mentioned in section 3.1 on the CBHG module, not on the general model architecture which indicates that is part of the CBHG module and apply the residual connection from its input (which is *after* the pre-net)
* You have used width=256 in the CBHG encoder, but in the paper is 128 mentioned. And I understand that it doesn't work if the residual connection is the input (character embedding, 256-dimensional). But if we use the connection from the pre-net it works as mentioned in the paper and we can use 128 in the whole encoder (last layer of pre-net has 128 units)

Hope this convinces you, if you have any concerns please comment.

# Highway-Net
The second part of this PR is directed at the code quality of the Highway-Net construction.
In particular it uses `tf.layers.dense` instead of the custom `dense` function and uses the number of units of `inputs` if not specified otherwise.

By using `tf.layers.dense` it simplifies the code (we could replace it in the pre-net as well) in my opinion.
Also, I haven't added batch normalization to the highway net construction, because I haven't seen batchnorm used much in FC layers (didn't notice much difference) and the paper only mentions batch-norm for conv-nets.

Oh and I dropped the `hp.embed_size`, so the code is more modular (and its also wrong IMO, see the first part of this PR)

Cheers,
André