### PR TITLE
 fix error use of conv1d in conv1d_banks

### DIFF
--- a/modules.py
+++ b/modules.py
@@ -177,7 +177,7 @@ def conv1d_banks(inputs, K=16, is_training=True, scope="conv1d_banks", reuse=Non
                             activation_fn=tf.nn.relu)
         for k in range(2, K+1): # k = 2...K
             with tf.variable_scope("num_{}".format(k)):
-                output = conv1d(inputs, k, hp.embed_size//2, 1)
+                output = conv1d(inputs, hp.embed_size // 2, k, 1)
                 output = normalize(output, type="bn", is_training=is_training, 
                             activation_fn=tf.nn.relu)
                 outputs = tf.concat((outputs, output), -1)


### PR DESCRIPTION
The method to call `conv1d` is wrong.

It should be:

```
filters = hp.embed_size // 2, size = k
```
Not
```
filters=k, size= hp.embed_size // 2
```

See
```
Args:
      inputs: A 3-D tensor with shape of [batch, time, depth].
      filters: An int. Number of outputs (=activation maps)
      size: An int. Filter size.
      rate: An int. Dilation rate.
      padding: Either `same` or `valid` or `causal` (case-insensitive).
      use_bias: A boolean.
      scope: Optional scope for `variable_scope`.
      reuse: Boolean, whether to reuse the weights of a previous layer
        by the same name.
```