### PR TITLE
Return linear-scale spectrogram rather than log-scale one.

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -39,7 +39,7 @@ def get_spectrograms(sound_file):
     # mel spectrogram
     S = librosa.feature.melspectrogram(S=power, n_mels=hp.n_mels) #(n_mels, T)
 
-    return np.transpose(S.astype(np.float32)), np.transpose(np.log(magnitude.astype(np.float32)+1e-10)) # (T, n_mels), (T, 1+n_fft/2)
+    return np.transpose(S.astype(np.float32)), np.transpose(magnitude.astype(np.float32)) # (T, n_mels), (T, 1+n_fft/2)
             
 def shift_by_one(inputs):
     '''Shifts the content of `inputs` to the right by one 


### PR DESCRIPTION
The paper did not specified usage of the log-scale spectrogram.
Also, if we want to use log-scale spectrogram, then we need to pad with -inf, not 0.