### PR TITLE
Pad (-infinity) for log-scale spectrogram

### DIFF
--- a/data_load.py
+++ b/data_load.py
@@ -145,8 +145,8 @@ def get_batch():
             _text = np.fromstring(_text, np.int32) # byte to int
             _spectrogram, _magnitude = get_spectrograms(_sound_file)
              
-            _spectrogram = reduce_frames(_spectrogram, hp.r)
-            _magnitude = reduce_frames(_magnitude, hp.r)
+            _spectrogram = reduce_frames(_spectrogram, hp.r, 0)
+            _magnitude = reduce_frames(_magnitude, hp.r, np.log(1e-10))
     
             return _text, _spectrogram, _magnitude
             

--- a/utils.py
+++ b/utils.py
@@ -39,7 +39,8 @@ def get_spectrograms(sound_file):
     # mel spectrogram
     S = librosa.feature.melspectrogram(S=power, n_mels=hp.n_mels) #(n_mels, T)
 
-    return np.transpose(S.astype(np.float32)), np.transpose(magnitude.astype(np.float32)) # (T, n_mels), (T, 1+n_fft/2)
+
+    return np.transpose(S.astype(np.float32)), np.transpose(np.log(magnitude.astype(np.float32)+1e-10)) # (T, n_mels), (T, 1+n_fft/2)
             
 def shift_by_one(inputs):
     '''Shifts the content of `inputs` to the right by one 
@@ -53,7 +54,7 @@ def shift_by_one(inputs):
     '''
     return tf.concat((tf.zeros_like(inputs[:, :1, :]), inputs[:, :-1, :]), 1)
 
-def reduce_frames(arry, r):
+def reduce_frames(arry, r, pad_val):
     '''Reduces and adjust the shape and content of `arry` according to r.
     
     Args:
@@ -66,7 +67,7 @@ def reduce_frames(arry, r):
     T, C = arry.shape
     num_paddings = hp.r - (T % r) if T % r != 0 else 0
      
-    padded = np.pad(arry, [[0, num_paddings], [0, 0]], 'constant')
+    padded = np.pad(arry, [[0, num_paddings], [0, 0]], 'constant', constant_values=pad_val)
     output = np.reshape(padded, (-1, C*r))
     return output
 

--- a/utils.py
+++ b/utils.py
@@ -39,7 +39,6 @@ def get_spectrograms(sound_file):
     # mel spectrogram
     S = librosa.feature.melspectrogram(S=power, n_mels=hp.n_mels) #(n_mels, T)
 
-
     return np.transpose(S.astype(np.float32)), np.transpose(np.log(magnitude.astype(np.float32)+1e-10)) # (T, n_mels), (T, 1+n_fft/2)
             
 def shift_by_one(inputs):

--- a/utils.py
+++ b/utils.py
@@ -39,7 +39,7 @@ def get_spectrograms(sound_file):
     # mel spectrogram
     S = librosa.feature.melspectrogram(S=power, n_mels=hp.n_mels) #(n_mels, T)
 
-    return np.transpose(S.astype(np.float32)), np.transpose(np.log(magnitude.astype(np.float32)+1e-10)) # (T, n_mels), (T, 1+n_fft/2)
+    return np.transpose(S.astype(np.float32)), np.transpose(magnitude.astype(np.float32)) # (T, n_mels), (T, 1+n_fft/2)
             
 def shift_by_one(inputs):
     '''Shifts the content of `inputs` to the right by one 


### PR DESCRIPTION
Originally spectrogram is 0 for silent part.
Since we applied log to the spectrogram, we should pad (-infinity) instead of 0.